### PR TITLE
Refactore webjars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,10 @@
 			<!-- On update replace version in htmls and ...HintConfig.java (needed for native) -->
 			<version>5.3.5</version>
 		</dependency>
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>webjars-locator-lite</artifactId>
+		</dependency>
 	</dependencies>
 
     <build>

--- a/src/main/java/de/viadee/k8s/testapp/config/NativeReflectionRuntimeHintConfig.java
+++ b/src/main/java/de/viadee/k8s/testapp/config/NativeReflectionRuntimeHintConfig.java
@@ -11,7 +11,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import java.util.HashMap;
 import java.util.Map;
 
-
 @Configuration
 @RegisterReflectionForBinding(classes = {HashMap.class})
 @ImportRuntimeHints(NativeReflectionRuntimeHintConfig.NativeRuntimeHints.class)
@@ -23,15 +22,10 @@ public class NativeReflectionRuntimeHintConfig {
         @Override
         public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
 
-            // especially for rendering k8s_env.html
+            // Register Map.Entry class for k8s_env.html template rendering
             hints.reflection().registerType(Map.Entry.class, MemberCategory.values());
-            // hints.reflection().registerType(HashMap.class, MemberCategory.values());
-            // inner classes
-           hints.reflection().registerTypeIfPresent(classLoader, "java.util.HashMap$Node"
-                    , MemberCategory.values());
-
-            hints.resources().registerPattern("META-INF/resources/webjars/bootstrap/5.3.5/css/bootstrap.min.css");
-            hints.resources().registerPattern("META-INF/resources/webjars/bootstrap/5.3.5/js/bootstrap.min.js");
+            // register inner class for for k8s_env.html template rendering
+            hints.reflection().registerTypeIfPresent(classLoader, "java.util.HashMap$Node", MemberCategory.values());
         }
     }
 }

--- a/src/main/java/de/viadee/k8s/testapp/config/WebConfig.java
+++ b/src/main/java/de/viadee/k8s/testapp/config/WebConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
+import org.springframework.web.servlet.resource.LiteWebJarsResourceResolver;
 
 @Configuration
 @EnableWebMvc
@@ -12,7 +12,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+        registry.addResourceHandler("/webjars/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/")
+                .resourceChain(true)
+                .addResolver(new LiteWebJarsResourceResolver());
     }
-
 }

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,4 +1,4 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" lang="en">
 <head>
 </head>
 <body>
@@ -9,7 +9,7 @@
         <footer>
 
         <script type="text/javascript"
-                src="webjars/bootstrap/5.3.5/js/bootstrap.min.js"></script>
+                src="webjars/bootstrap/js/bootstrap.min.js"></script>
 
         </footer>
     </div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,9 +1,9 @@
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
 <head>
     <div th:fragment="header-css">
         <!-- this is header-css -->
         <link rel="stylesheet" type="text/css"
-              href="webjars/bootstrap/5.3.5/css/bootstrap.min.css" />
+              href="webjars/bootstrap/css/bootstrap.min.css" />
         <title>K8s Test App</title>
     </div>
 </head>


### PR DESCRIPTION
Add webjars-locator-lite dependency and configure LiteWebJarsResourceResolver to provide version agnostic URLs that are native image compatible

- Introduced `webjars-locator-lite` dependency in `pom.xml` for better handling of webjars resources.
- Updated `WebConfig` to utilize `LiteWebJarsResourceResolver` for resolving webjars resources.
- Fixed resource paths in footer and header templates to align with webjars structure.
- Cleaned up `NativeReflectionRuntimeHintConfig` and adjusted hint registrations for template rendering.
