### PR TITLE
update Dockerfiles to use JDK 25 and improve user permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM openjdk:21-slim
-COPY target/k8s-demo-app.jar app.jar
-RUN groupadd -g 1000 appuser && \
-    useradd -u 1000 -g 1000 appuser
-USER appuser
+FROM eclipse-temurin:25-jre-alpine
 
+RUN apk add --no-cache shadow && \
+    groupadd -g 1000 appuser && \
+    useradd -u 1000 -g 1000 -m appuser && \
+    mkdir -p /app && \
+    chown -R appuser:appuser /app && \
+    apk del shadow
+
+WORKDIR /app
+COPY --chown=appuser:appuser target/k8s-demo-app.jar app.jar
+
+USER appuser
 EXPOSE 8080/tcp
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile.Multistage
+++ b/Dockerfile.Multistage
@@ -1,18 +1,25 @@
-FROM maven:3.9-amazoncorretto-21-alpine AS build_container
+FROM maven:3.9-amazoncorretto-25-alpine AS build_container
 
 WORKDIR /build
 COPY pom.xml .
 RUN mvn dependency:go-offline -B
 
-COPY  . /usr/src/build
-WORKDIR /usr/src/build
+COPY . .
 RUN mvn package -B
 
-FROM openjdk:21-slim
-COPY --from=build_container /usr/src/build/target/k8s-demo-app.jar app.jar
-RUN groupadd -g 1000 appuser && \
-    useradd -u 1000 -g 1000 appuser
+FROM eclipse-temurin:25-jre-alpine
+
+RUN apk add --no-cache shadow && \
+    groupadd -g 1000 appuser && \
+    useradd -u 1000 -g 1000 -m appuser && \
+    mkdir -p /app && \
+    chown -R appuser:appuser /app && \
+    apk del shadow
+
+WORKDIR /app
+COPY --from=build_container --chown=appuser:appuser /build/target/k8s-demo-app.jar app.jar
+
 USER appuser
 
 EXPOSE 8080/tcp
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/DockerfileNative
+++ b/DockerfileNative
@@ -1,13 +1,20 @@
-FROM alpine
+FROM alpine:latest
 
 # prepare to run glibc programs
 RUN apk add gcompat
 
+# Create non-root user
+RUN apk add --no-cache shadow && \
+    groupadd -g 1000 appuser && \
+    useradd -u 1000 -g 1000 -m appuser && \
+    mkdir -p /app && \
+    chown -R appuser:appuser /app
+
 WORKDIR /app
 
 # Copy the native binary from the build stage
-COPY target/k8s-demo-app .
+COPY --chown=appuser:appuser target/k8s-demo-app .
 
-# Run the application
+USER appuser
 EXPOSE 8080/tcp
 ENTRYPOINT ["/app/k8s-demo-app"]

--- a/DockerfileNative.Multistage
+++ b/DockerfileNative.Multistage
@@ -1,5 +1,5 @@
 # First stage: JDK with GraalVM
-FROM container-registry.oracle.com/graalvm/native-image:24 AS build
+FROM container-registry.oracle.com/graalvm/native-image:25 AS build
 
 # Update package lists and Install Maven
 RUN microdnf install -y maven
@@ -20,16 +20,23 @@ RUN mvn -PnativeTest test
 RUN mvn -Pnative -DskipTests clean native:compile
 
 ## Second stage: Lightweight image
-FROM alpine
+FROM alpine:latest
 
 # prepare to run glibc programs
 RUN apk add gcompat
 
+# Create non-root user
+RUN apk add --no-cache shadow && \
+    groupadd -g 1000 appuser && \
+    useradd -u 1000 -g 1000 -m appuser && \
+    mkdir -p /app && \
+    chown -R appuser:appuser /app
+
 WORKDIR /app
 
 # Copy the native binary from the build stage
-COPY --from=build /usr/src/app/target/k8s-demo-app /app/k8s-demo-app
+COPY --from=build --chown=appuser:appuser /usr/src/app/target/k8s-demo-app /app/k8s-demo-app
 
-# Run the application
+USER appuser
 EXPOSE 8080/tcp
 ENTRYPOINT ["/app/k8s-demo-app"]


### PR DESCRIPTION
Short notes on this PR:

- Bumped Dockerfiles to JDK 25
   - groupadd and useradd are not installed by default, thus added the shadow package via apk (apk add shadow), removal of that package after usage of groupadd and useradd
- Standardized the use of WORKDIR (suggested by Copilot)
- Added chown to each COPY so the permissions are correct (suggested by Copilot)