### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_push_to_ecr.yaml
+++ b/.github/workflows/build_push_to_ecr.yaml
@@ -2,6 +2,8 @@ name: build release and push to ECR
 on:
   release:
     types: [prereleased, released]
+permissions:
+  contents: read
 jobs:
   build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/native_build.yaml
+++ b/.github/workflows/native_build.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/native_build_push_to_ecr.yaml
+++ b/.github/workflows/native_build_push_to_ecr.yaml
@@ -2,6 +2,8 @@ name: build native release and push to ECR
 on:
   release:
     types: [prereleased, released]
+permissions:
+  contents: read
 jobs:
   build_and_push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/viadee/k8s-demo-app/security/code-scanning/4](https://github.com/viadee/k8s-demo-app/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root (top-level), so it applies to all jobs unless overridden. For this workflow, `contents: read` is the correct minimal permission and preserves current functionality (checkout/build/test/upload artifact). No imports, methods, or dependencies are needed—only YAML configuration in `.github/workflows/native_build.yaml`.

**Where to change:**
- File: `.github/workflows/native_build.yaml`
- Insert `permissions:` after the `on:` trigger block and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
